### PR TITLE
fix: Add Update Load Balancer Frontend Struct and Method

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/utho-go.iml" filepath="$PROJECT_DIR$/.idea/utho-go.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/utho-go.iml
+++ b/.idea/utho-go.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/utho/load_balancer.go
+++ b/utho/load_balancer.go
@@ -107,7 +107,7 @@ type CreateLoadbalancerParams struct {
 }
 type CreateLoadbalancerResponse struct {
 	Status  string `json:"status"`
-	ID      string `json:"loadbalancerid"`
+	ID      string `json:"lbid"`
 	Message string `json:"message"`
 }
 
@@ -266,6 +266,17 @@ type CreateLoadbalancerFrontendParams struct {
 	Cookie         string `json:"cookie"`
 }
 
+type UpdateLoadbalancerFrontendParams struct {
+	LoadbalancerId string
+	Name           string `json:"name"`
+	Proto          string `json:"proto"`
+	Port           string `json:"port"`
+	CertificateID  string `json:"certificate_id,omitempty"`
+	Algorithm      string `json:"algorithm"`
+	Redirecthttps  string `json:"redirecthttps,omitempty"`
+	Cookie         string `json:"cookie"`
+}
+
 func (s *LoadbalancersService) CreateFrontend(params CreateLoadbalancerFrontendParams) (*CreateResponse, error) {
 	reqUrl := "loadbalancer/" + params.LoadbalancerId + "/frontend"
 	req, _ := s.client.NewRequest("POST", reqUrl, &params)
@@ -282,6 +293,20 @@ func (s *LoadbalancersService) CreateFrontend(params CreateLoadbalancerFrontendP
 	return &loadbalancerFrontend, nil
 }
 
+func (s *LoadbalancersService) UpdateFrontend(params UpdateLoadbalancerFrontendParams, loadbalancerId, loadbalancerFrontendId string) (*UpdateResponse, error) {
+	reqUrl := "loadbalancer/" + loadbalancerId + "/frontend/" + loadbalancerFrontendId
+	req, _ := s.client.NewRequest("PUT", reqUrl, &params)
+
+	var frontend UpdateResponse
+	if _, err := s.client.Do(req, &frontend); err != nil {
+		return nil, err
+	}
+
+	if frontend.Status != "success" && frontend.Status != "" {
+		return nil, errors.New(frontend.Message)
+	}
+	return &frontend, nil
+}
 func (s *LoadbalancersService) ReadFrontend(loadbalancerId, loadbalancerFrontendId string) (*Frontends, error) {
 	reqUrl := "loadbalancer/" + loadbalancerId
 	req, _ := s.client.NewRequest("GET", reqUrl)

--- a/utho/load_balancer.go
+++ b/utho/load_balancer.go
@@ -107,7 +107,7 @@ type CreateLoadbalancerParams struct {
 }
 type CreateLoadbalancerResponse struct {
 	Status  string `json:"status"`
-	ID      string `json:"lbid"`
+	ID      string `json:"loadbalancerid"`
 	Message string `json:"message"`
 }
 


### PR DESCRIPTION
### What this PR fixes:
1. The Response from the API when Creating a Load Balancer has an lbid field. However, the CreateLoadbalancerParams struct has the json tag of "loadbalancerid" which doesn't unmarshall to the right field
2. There is no UpdateFrontend Method or UpdateLoadbalancerFrontendParams available. Added Support for that.